### PR TITLE
Make it compile in CMSSW_7_6_X

### DIFF
--- a/plugins/AddPtRatioPtRel.cc
+++ b/plugins/AddPtRatioPtRel.cc
@@ -39,8 +39,8 @@ private:
   virtual void endJob();
 
   // ----------member data ---------------------------
-  const edm::InputTag probes_;    
-  const edm::InputTag jets_;    
+  const edm::EDGetTokenT<edm::View<reco::Candidate>> probes_;    
+  const edm::EDGetTokenT<std::vector<reco::PFJet>> jets_;    
   const double dRmax_;
   const bool subLepFromJetForPtRel_;
 };
@@ -58,8 +58,8 @@ private:
 // constructors and destructor
 //
 AddPtRatioPtRel::AddPtRatioPtRel(const edm::ParameterSet& iConfig):
-probes_(iConfig.getParameter<edm::InputTag>("probes")),
-jets_(iConfig.getParameter<edm::InputTag>("jets")),
+probes_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("probes"))),
+jets_(consumes<std::vector<reco::PFJet>>(iConfig.getParameter<edm::InputTag>("jets"))),
 dRmax_(iConfig.getParameter<double>("dRmax")),
 subLepFromJetForPtRel_(iConfig.getParameter<bool>("subLepFromJetForPtRel"))
 {
@@ -93,11 +93,11 @@ AddPtRatioPtRel::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   using namespace edm;
 
   Handle<View<reco::Candidate> > probes;
-  iEvent.getByLabel(probes_, probes);
+  iEvent.getByToken(probes_, probes);
 
   //Aussi  mettre jet dans le fichier de configuration
   Handle<std::vector<reco::PFJet> > Jets;
-  iEvent.getByLabel(jets_, Jets);
+  iEvent.getByToken(jets_, Jets);
   //iEvent.getByLabel("ak4PFJetsCHS", Jets);
 
   //Output

--- a/plugins/BestPairByMass.cc
+++ b/plugins/BestPairByMass.cc
@@ -51,7 +51,7 @@ class BestPairByMass : public edm::EDProducer {
         virtual void produce(edm::Event&, const edm::EventSetup&);
 
         /// The Tags
-        edm::InputTag pairs_;
+        edm::EDGetTokenT<edm::View<reco::Candidate>> pairs_;
 
         /// Mass value and window
         double mass_;
@@ -61,7 +61,7 @@ class BestPairByMass : public edm::EDProducer {
 };
 
 BestPairByMass::BestPairByMass(const edm::ParameterSet &iConfig) :
-    pairs_(iConfig.getParameter<edm::InputTag>("pairs")),
+    pairs_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("pairs"))),
     mass_(iConfig.getParameter<double>("mass"))
 {
     produces<edm::RefToBaseVector<reco::Candidate> >();
@@ -75,7 +75,7 @@ void
 BestPairByMass::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
     edm::Handle<edm::View<reco::Candidate> > pairs; 
-    iEvent.getByLabel(pairs_, pairs);
+    iEvent.getByToken(pairs_, pairs);
 
     // Filter and fill
     size_t i, n = pairs->size(); 

--- a/plugins/ComputeIsoCorrections.cc
+++ b/plugins/ComputeIsoCorrections.cc
@@ -54,7 +54,7 @@ private:
   virtual void endJob() ;
 
   // ----------member data ---------------------------
-  const edm::InputTag probesLabel;
+  const edm::EDGetTokenT<edm::View<pat::Muon>> probesLabel;
 
 };
 
@@ -71,7 +71,7 @@ private:
 // constructors and destructor
 //
 ComputeIsoCorrections::ComputeIsoCorrections(const edm::ParameterSet& iConfig):
-  probesLabel(iConfig.getParameter<edm::InputTag>("probes"))
+  probesLabel(consumes<edm::View<pat::Muon>>(iConfig.getParameter<edm::InputTag>("probes")))
 {
 
   produces<edm::ValueMap<float> >("fixedGridRhoFastjetAllCalo");
@@ -95,7 +95,7 @@ void ComputeIsoCorrections::produce(edm::Event& iEvent, const edm::EventSetup& i
 
   // Read input
   Handle<View<pat::Muon> > probes;
-  iEvent.getByLabel(probesLabel, probes);
+  iEvent.getByToken(probesLabel, probes);
   
   // Rho values
   edm::Handle<double> fixedGridRhoFastjetAllH;

--- a/plugins/ComputeIsoCorrections.cc
+++ b/plugins/ComputeIsoCorrections.cc
@@ -55,7 +55,11 @@ private:
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<edm::View<pat::Muon>> probesLabel;
-
+  edm::EDGetTokenT<double> fixedGridRhoFastjetAllCalo_;
+  edm::EDGetTokenT<double> fixedGridRhoFastjetAll_;
+  edm::EDGetTokenT<double> fixedGridRhoFastjetCentralChargedPileUp_;
+  edm::EDGetTokenT<double> fixedGridRhoFastjetCentralNeutral_;
+  edm::EDGetTokenT<double> fixedGridRhoFastjetCentralCalo_;
 };
 
 //
@@ -71,7 +75,12 @@ private:
 // constructors and destructor
 //
 ComputeIsoCorrections::ComputeIsoCorrections(const edm::ParameterSet& iConfig):
-  probesLabel(consumes<edm::View<pat::Muon>>(iConfig.getParameter<edm::InputTag>("probes")))
+  probesLabel(consumes<edm::View<pat::Muon>>(iConfig.getParameter<edm::InputTag>("probes"))),
+  fixedGridRhoFastjetAllCalo_(consumes<double>(edm::InputTag("fixedGridRhoFastjetAllCalo"))),
+  fixedGridRhoFastjetAll_(consumes<double>(edm::InputTag("fixedGridRhoFastjetAll"))),
+  fixedGridRhoFastjetCentralChargedPileUp_(consumes<double>(edm::InputTag("fixedGridRhoFastjetCentralChargedPileUp"))),
+  fixedGridRhoFastjetCentralNeutral_(consumes<double>(edm::InputTag("fixedGridRhoFastjetCentralNeutral"))),
+  fixedGridRhoFastjetCentralCalo_(consumes<double>(edm::InputTag("fixedGridRhoFastjetCentralCalo"))) 
 {
 
   produces<edm::ValueMap<float> >("fixedGridRhoFastjetAllCalo");
@@ -99,19 +108,19 @@ void ComputeIsoCorrections::produce(edm::Event& iEvent, const edm::EventSetup& i
   
   // Rho values
   edm::Handle<double> fixedGridRhoFastjetAllH;
-  iEvent.getByLabel(InputTag("fixedGridRhoFastjetAll", ""), fixedGridRhoFastjetAllH);
+  iEvent.getByToken(fixedGridRhoFastjetAll_, fixedGridRhoFastjetAllH);
 
   edm::Handle<double> fixedGridRhoFastjetAllCaloH;
-  iEvent.getByLabel(InputTag("fixedGridRhoFastjetAllCalo", ""), fixedGridRhoFastjetAllCaloH);
+  iEvent.getByToken(fixedGridRhoFastjetAllCalo_, fixedGridRhoFastjetAllCaloH);
 
   edm::Handle<double> fixedGridRhoFastjetCentralCaloH;
-  iEvent.getByLabel(InputTag("fixedGridRhoFastjetCentralCalo", ""), fixedGridRhoFastjetCentralCaloH);
+  iEvent.getByToken(fixedGridRhoFastjetCentralCalo_, fixedGridRhoFastjetCentralCaloH);
 
   edm::Handle<double> fixedGridRhoFastjetCentralChargedPileUpH;
-  iEvent.getByLabel(InputTag("fixedGridRhoFastjetCentralChargedPileUp", ""), fixedGridRhoFastjetCentralChargedPileUpH);
+  iEvent.getByToken(fixedGridRhoFastjetCentralChargedPileUp_, fixedGridRhoFastjetCentralChargedPileUpH);
   
   edm::Handle<double> fixedGridRhoFastjetCentralNeutralH;
-  iEvent.getByLabel(InputTag("fixedGridRhoFastjetCentralNeutral", ""), fixedGridRhoFastjetCentralNeutralH);
+  iEvent.getByToken(fixedGridRhoFastjetCentralNeutral_, fixedGridRhoFastjetCentralNeutralH);
 
 
   // Prepare vector for output 

--- a/plugins/ComputeL1HLTPrescales.cc
+++ b/plugins/ComputeL1HLTPrescales.cc
@@ -1,3 +1,4 @@
+#if 0
 // system include files
 #include <memory>
 #include <cmath>
@@ -30,7 +31,7 @@ private:
   virtual void beginRun(edm::Run&, edm::EventSetup const&);
 
   // ----------member data ---------------------------
-  const edm::InputTag probesLabel_;
+  const edm::EDGetTokenT<edm::View<reco::Candidate>> probesLabel_;
   const std::string hltConfigLabel_;
   std::vector<std::string> hltPaths_;
   HLTConfigProvider hltConfig_;
@@ -39,7 +40,7 @@ private:
 };
 
 ComputeL1HLTPrescales::ComputeL1HLTPrescales(const edm::ParameterSet& iConfig):
-  probesLabel_(iConfig.getParameter<edm::InputTag>("probes")),
+  probesLabel_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("probes"))),
   hltConfigLabel_(iConfig.getParameter<std::string>("hltConfig")),
   hltPaths_(iConfig.getParameter<std::vector<std::string> >("hltPaths"))
 {
@@ -60,7 +61,7 @@ void ComputeL1HLTPrescales::produce(edm::Event& iEvent, const edm::EventSetup& i
 
   // Read input
   Handle<View<reco::Candidate> > probes;
-  iEvent.getByLabel(probesLabel_, probes);
+  iEvent.getByToken(probesLabel_, probes);
 
   if(!hltConfig_.inited()) {
     for(unsigned int j=0; j<hltPaths_.size(); ++j) {
@@ -113,3 +114,4 @@ void ComputeL1HLTPrescales::writeGlobalFloat(edm::Event &iEvent, const edm::Hand
 
 // Define this module as plugin
 DEFINE_FWK_MODULE(ComputeL1HLTPrescales);
+#endif

--- a/plugins/ComputeL1TriggerRate.cc
+++ b/plugins/ComputeL1TriggerRate.cc
@@ -29,15 +29,15 @@ private:
   virtual void produce(edm::Event&, const edm::EventSetup&);
 
   // ----------member data ---------------------------
-  const edm::InputTag probesLabel_;
-  const edm::InputTag scalersLabel_;
+  const edm::EDGetTokenT<edm::View<reco::Candidate>> probesLabel_;
+  const edm::EDGetTokenT<std::vector<Level1TriggerScalers>> scalersLabel_;
 
   void writeGlobalFloat(edm::Event &iEvent, const edm::Handle<edm::View<reco::Candidate> > &probes, const double value, const std::string &label) ;
 };
 
 ComputeL1TriggerRate::ComputeL1TriggerRate(const edm::ParameterSet& iConfig):
-  probesLabel_(iConfig.getParameter<edm::InputTag>("probes")),
-  scalersLabel_(iConfig.getParameter<edm::InputTag>("scalers"))
+  probesLabel_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("probes"))),
+  scalersLabel_(consumes<std::vector<Level1TriggerScalers>>(iConfig.getParameter<edm::InputTag>("scalers")))
 {
   produces<edm::ValueMap<float> >();
   produces<edm::ValueMap<float> >("bx");
@@ -52,10 +52,10 @@ void ComputeL1TriggerRate::produce(edm::Event& iEvent, const edm::EventSetup& iS
 
   // Read input
   Handle<View<reco::Candidate> > probes;
-  iEvent.getByLabel(probesLabel_, probes);
+  iEvent.getByToken(probesLabel_, probes);
 
   edm::Handle<std::vector<Level1TriggerScalers> > scalers; 
-  iEvent.getByLabel(scalersLabel_, scalers); 
+  iEvent.getByToken(scalersLabel_, scalers); 
 
   writeGlobalFloat(iEvent, probes, scalers->empty() ? -1 : scalers->front().gtTriggersRate(), "");
   writeGlobalFloat(iEvent, probes, iEvent.bunchCrossing(), "bx");

--- a/plugins/ComputeLogErrorTotals.cc
+++ b/plugins/ComputeLogErrorTotals.cc
@@ -34,8 +34,8 @@ private:
   virtual void produce(edm::Event&, const edm::EventSetup&);
 
   // ----------member data ---------------------------
-  edm::InputTag probesLabel_;
-  edm::InputTag logErrorLabel_;
+  edm::EDGetTokenT<edm::View<reco::Candidate>> probesLabel_;
+  edm::EDGetTokenT<std::vector<edm::ErrorSummaryEntry>> logErrorLabel_;
 
   std::map<std::string, std::set<std::string> > counters_;
 
@@ -43,8 +43,8 @@ private:
 };
 
 ComputeLogErrorTotals::ComputeLogErrorTotals(const edm::ParameterSet& iConfig):
-  probesLabel_(iConfig.getParameter<edm::InputTag>("probes")),
-  logErrorLabel_(iConfig.getParameter<edm::InputTag>("logErrors"))
+  probesLabel_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("probes"))),
+  logErrorLabel_(consumes<std::vector<edm::ErrorSummaryEntry>>(iConfig.getParameter<edm::InputTag>("logErrors")))
 {
     edm::ParameterSet idps = iConfig.getParameter<edm::ParameterSet>("counters");
     std::vector<std::string> names = idps.getParameterNamesForType<std::vector<std::string> >();
@@ -64,10 +64,10 @@ void ComputeLogErrorTotals::produce(edm::Event& iEvent, const edm::EventSetup& i
 
   // Read input
   Handle<View<reco::Candidate> > probes;
-  iEvent.getByLabel(probesLabel_, probes);
+  iEvent.getByToken(probesLabel_, probes);
 
   edm::Handle<std::vector<edm::ErrorSummaryEntry> >  errors;
-  iEvent.getByLabel(logErrorLabel_,errors);
+  iEvent.getByToken(logErrorLabel_,errors);
 
   // Compare severity level of error with ELseveritylevel instance el : "-e" should be the lowest error
   edm::ELseverityLevel el("-e");

--- a/plugins/ComputeTkClusterInfos.cc
+++ b/plugins/ComputeTkClusterInfos.cc
@@ -29,16 +29,17 @@ private:
   virtual void produce(edm::Event&, const edm::EventSetup&);
 
   // ----------member data ---------------------------
-  const edm::InputTag probesLabel_;
-  const edm::InputTag stripLabel_, pixelLabel_;
+  const edm::EDGetTokenT<edm::View<reco::Candidate>> probesLabel_;
+  const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster>> stripLabel_;
+  const edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> pixelLabel_;
 
   void writeGlobalFloat(edm::Event &iEvent, const edm::Handle<edm::View<reco::Candidate> > &probes, const double value, const std::string &label) ;
 };
 
 ComputeTkClusterInfos::ComputeTkClusterInfos(const edm::ParameterSet& iConfig):
-  probesLabel_(iConfig.getParameter<edm::InputTag>("probes")),
-  stripLabel_(iConfig.getParameter<edm::InputTag>("stripClusters")),
-  pixelLabel_(iConfig.getParameter<edm::InputTag>("pixelClusters"))
+  probesLabel_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("probes"))),
+  stripLabel_(consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("stripClusters"))),
+  pixelLabel_(consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("pixelClusters")))
 {
 
   produces<edm::ValueMap<float> >("siStripClusterCount");
@@ -54,12 +55,12 @@ void ComputeTkClusterInfos::produce(edm::Event& iEvent, const edm::EventSetup& i
 
   // Read input
   Handle<View<reco::Candidate> > probes;
-  iEvent.getByLabel(probesLabel_, probes);
+  iEvent.getByToken(probesLabel_, probes);
 
   edm::Handle<edmNew::DetSetVector<SiStripCluster> > stripC; 
   edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelC; 
-  iEvent.getByLabel(stripLabel_, stripC); 
-  iEvent.getByLabel(pixelLabel_, pixelC); 
+  iEvent.getByToken(stripLabel_, stripC); 
+  iEvent.getByToken(pixelLabel_, pixelC); 
 
   writeGlobalFloat(iEvent, probes, stripC->dataSize(), "siStripClusterCount");
   writeGlobalFloat(iEvent, probes, pixelC->dataSize(), "siPixelClusterCount");

--- a/plugins/ExpectedHitsComputer.cc
+++ b/plugins/ExpectedHitsComputer.cc
@@ -49,7 +49,7 @@ public:
   virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
 
 private:
-  edm::InputTag input_;
+  edm::EDGetTokenT<edm::View<reco::RecoCandidate>> input_;
   bool useGsfTrack_;
   StringCutObjectSelector<reco::Candidate,true> objCut_; 
   std::string thePropName;      
@@ -58,7 +58,7 @@ private:
 };
 
 ExpectedHitsComputer::ExpectedHitsComputer(const edm::ParameterSet & iConfig) :
-  input_(iConfig.getParameter<edm::InputTag>("inputColl")),
+  input_(consumes<edm::View<reco::RecoCandidate>>(iConfig.getParameter<edm::InputTag>("inputColl"))),
   useGsfTrack_(iConfig.getParameter<bool>("useGsfTrack")),
   objCut_(iConfig.existsAs<std::string>("objectSelection") ? iConfig.getParameter<std::string>("objectSelection") : "", true)
 {
@@ -103,7 +103,7 @@ ExpectedHitsComputer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 
   // read input
   Handle<View<reco::RecoCandidate> > inputCands;
-  iEvent.getByLabel(input_,  inputCands);
+  iEvent.getByToken(input_,  inputCands);
 
   // prepare vector for output    
   std::vector<int> innerValues;

--- a/plugins/GenWeightInfo.cc
+++ b/plugins/GenWeightInfo.cc
@@ -34,8 +34,8 @@ public:
 
 private:
 
-  edm::InputTag m_genInfoTag;
-  edm::InputTag m_pairTag;
+  edm::EDGetTokenT<GenEventInfoProduct> m_genInfoTag;
+  edm::EDGetTokenT<edm::View<reco::Candidate>> m_pairTag;
 
   /// Write a ValueMap<float> in the event
   void writeValueMap(edm::Event &ev, const edm::Handle<edm::View<reco::Candidate> > & handle,
@@ -45,8 +45,8 @@ private:
 
 
 GenWeightInfo::GenWeightInfo(const edm::ParameterSet & iConfig) :
-  m_genInfoTag(iConfig.getParameter<edm::InputTag>("genInfoTag")),
-  m_pairTag(iConfig.getParameter<edm::InputTag>("pairTag"))
+  m_genInfoTag(consumes<GenEventInfoProduct>(iConfig.getParameter<edm::InputTag>("genInfoTag"))),
+  m_pairTag(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("pairTag")))
 {
   
   produces<edm::ValueMap<float> >("genWeight");
@@ -61,13 +61,13 @@ void GenWeightInfo::produce(edm::Event & ev, const edm::EventSetup & iSetup)
   if (!ev.isRealData())
     {
       edm::Handle<GenEventInfoProduct> genInfo;
-      ev.getByLabel(m_genInfoTag, genInfo);
+      ev.getByToken(m_genInfoTag, genInfo);
 
       weight = genInfo->weight();
     } 
   
   edm::Handle<edm::View<reco::Candidate> > pairs;
-  ev.getByLabel(m_pairTag, pairs);
+  ev.getByToken(m_pairTag, pairs);
 
   size_t n = pairs->size();
   std::vector<float> genWeight(n,0);

--- a/plugins/HighPtMuonsInfo.cc
+++ b/plugins/HighPtMuonsInfo.cc
@@ -32,7 +32,7 @@ class HighPtMuonsInfo : public edm::EDProducer {
 
       virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
     private:
-        edm::InputTag src_;
+        edm::EDGetTokenT<edm::View<reco::Candidate>> src_;
 
         /// Write a ValueMap<float> in the event
         void writeValueMap(edm::Event &iEvent,
@@ -43,7 +43,7 @@ class HighPtMuonsInfo : public edm::EDProducer {
 };
 
 HighPtMuonsInfo::HighPtMuonsInfo(const edm::ParameterSet & iConfig) :
-    src_(iConfig.getParameter<edm::InputTag>("src"))
+    src_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src")))
 {
     produces<edm::ValueMap<float> >("pt");
     produces<edm::ValueMap<float> >("ptRelError");
@@ -57,7 +57,7 @@ HighPtMuonsInfo::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
     using namespace std;
 
     Handle<View<reco::Candidate> > src;
-    iEvent.getByLabel(src_, src);
+    iEvent.getByToken(src_, src);
 
     size_t n = src->size();
     std::vector<float> pt(n,0), ptRelError(n,0), mass(n, -999), trackType(n,-999);

--- a/plugins/InefficiencyCreator.cc
+++ b/plugins/InefficiencyCreator.cc
@@ -65,7 +65,7 @@ class InefficiencyCreator : public edm::EDProducer {
         virtual void produce(edm::Event&, const edm::EventSetup&);
 
         /// The RECO objects
-        edm::InputTag src_;
+        edm::EDGetTokenT<edm::View<T>> src_;
 
         typedef StringObjectFunction<T> Function;
         /// The Probability
@@ -79,7 +79,7 @@ class InefficiencyCreator : public edm::EDProducer {
 
 template<typename T>
 InefficiencyCreator<T>::InefficiencyCreator(const edm::ParameterSet &iConfig) :
-    src_(iConfig.getParameter<edm::InputTag>("src")),
+    src_(consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("src"))),
     probability_(iConfig.getParameter<std::string>("probability"))
 {
   if ( ! rng_.isAvailable()) {
@@ -114,7 +114,7 @@ void
 InefficiencyCreator<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
     edm::Handle<edm::View<T> > src; 
-    iEvent.getByLabel(src_, src);
+    iEvent.getByToken(src_, src);
 
     CLHEP::HepRandomEngine& engine = rng_->getEngine( iEvent.streamID() );
 

--- a/plugins/MatchedCandidateSelector.cc
+++ b/plugins/MatchedCandidateSelector.cc
@@ -38,12 +38,13 @@ class MatchedCandidateSelector : public edm::EDProducer {
         virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
 
     private:
-        edm::InputTag src_, match_;
+        edm::EDGetTokenT<edm::View<reco::Candidate>> src_;
+        edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr>> match_;
 };
 
 MatchedCandidateSelector::MatchedCandidateSelector(const edm::ParameterSet & iConfig) :
-    src_(iConfig.getParameter<edm::InputTag>("src")), 
-    match_(iConfig.getParameter<edm::InputTag>("match")) 
+    src_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))), 
+    match_(consumes<edm::ValueMap<reco::CandidatePtr>>(iConfig.getParameter<edm::InputTag>("match"))) 
 {
     produces<reco::CandidateBaseRefVector>();
     produces<reco::CandidateBaseRefVector>("unmatched");
@@ -54,9 +55,9 @@ MatchedCandidateSelector::produce(edm::Event & iEvent, const edm::EventSetup & i
     using namespace edm;
 
     Handle<View<reco::Candidate> > src;
-    iEvent.getByLabel(src_, src);
+    iEvent.getByToken(src_, src);
     Handle<ValueMap<reco::CandidatePtr> > match;
-    iEvent.getByLabel(match_, match);
+    iEvent.getByToken(match_, match);
 
     std::auto_ptr<reco::CandidateBaseRefVector >  out( new reco::CandidateBaseRefVector());
     std::auto_ptr<reco::CandidateBaseRefVector >  fail(new reco::CandidateBaseRefVector());

--- a/plugins/MatcherUsingTracksWithTagAssoc.cc
+++ b/plugins/MatcherUsingTracksWithTagAssoc.cc
@@ -38,10 +38,10 @@ namespace pat {
 
     private:
       /// Labels for input collections
-      edm::InputTag src_, matched_;
+      edm::EDGetTokenT<edm::View<reco::Candidate>> src_, matched_;
 
       /// Tags to preselect probes on 
-      edm::InputTag tags_;
+      edm::EDGetTokenT<edm::View<reco::Candidate>> tags_;
       double deltaZ_;
 
       /// The real workhorse
@@ -63,9 +63,9 @@ namespace pat {
 } // namespace
 
 pat::MatcherUsingTracksWithTagAssoc::MatcherUsingTracksWithTagAssoc(const edm::ParameterSet & iConfig) :
-    src_(iConfig.getParameter<edm::InputTag>("src")),
-    matched_(iConfig.getParameter<edm::InputTag>("matched")),
-    tags_(iConfig.getParameter<edm::InputTag>("tags")),
+    src_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))),
+    matched_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("matched"))),
+    tags_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("tags"))),
     deltaZ_(iConfig.getParameter<double>("tagDeltaZ")),
     algo_(iConfig),
     dontFailOnMissingInput_(iConfig.existsAs<bool>("dontFailOnMissingInput") ? iConfig.getParameter<bool>("dontFailOnMissingInput") : false)
@@ -101,9 +101,9 @@ pat::MatcherUsingTracksWithTagAssoc::produce(edm::Event & iEvent, const edm::Eve
 
     Handle<View<reco::Candidate> > src, matched, tags;
 
-    iEvent.getByLabel(src_, src);
-    iEvent.getByLabel(matched_, matched);
-    iEvent.getByLabel(tags_, tags);
+    iEvent.getByToken(src_, src);
+    iEvent.getByToken(matched_, matched);
+    iEvent.getByToken(tags_, tags);
 
     // declare loop variables and some intermediate stuff
     View<reco::Candidate>::const_iterator itsrc, edsrc = src->end(); 

--- a/plugins/MuonDxyPVdzmin.cc
+++ b/plugins/MuonDxyPVdzmin.cc
@@ -41,7 +41,7 @@ private:
   virtual void endJob() ;
 
   // ----------member data ---------------------------
-  const edm::InputTag probes_;    
+  const edm::EDGetTokenT<edm::View<reco::Muon>> probes_;    
 };
 
 //
@@ -57,7 +57,7 @@ private:
 // constructors and destructor
 //
 MuonDxyPVdzmin::MuonDxyPVdzmin(const edm::ParameterSet& iConfig):
-probes_(iConfig.getParameter<edm::InputTag>("probes"))
+probes_(consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("probes")))
 
 {
   produces<edm::ValueMap<float> >("dxyBS");
@@ -87,7 +87,7 @@ MuonDxyPVdzmin::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   // read input
   Handle<View<reco::Muon> > probes;
-  iEvent.getByLabel(probes_,  probes);
+  iEvent.getByToken(probes_,  probes);
   
   edm::Handle<std::vector<reco::Vertex> > primaryVerticesHandle;
   iEvent.getByLabel("offlinePrimaryVertices", primaryVerticesHandle);

--- a/plugins/MuonMVAIsoVariables.cc
+++ b/plugins/MuonMVAIsoVariables.cc
@@ -36,12 +36,12 @@ private:
   virtual void endJob() ;
 
   // ----------member data ---------------------------
-  const edm::InputTag probes_;    
+  const edm::EDGetTokenT<edm::View<reco::Muon>> probes_;    
   const bool doOverlapRemoval_;
-  const edm::InputTag goodElectrons_;    
-  const edm::InputTag goodMuons_;    
-  const edm::InputTag pfCandidates_;
-  const edm::InputTag vertices_;
+  const edm::EDGetTokenT<edm::View<reco::GsfElectron>> goodElectrons_;    
+  const edm::EDGetTokenT<edm::View<reco::Muon>> goodMuons_;    
+  const edm::EDGetTokenT<edm::View<reco::PFCandidate>> pfCandidates_;
+  const edm::EDGetTokenT<reco::VertexCollection> vertices_;
   const double dzCut_, photonPtMin_, neutralHadPtMin_;
 
   /// Store extra information in a ValueMap
@@ -65,12 +65,12 @@ private:
 // constructors and destructor
 //
 MuonMVAIsoVariables::MuonMVAIsoVariables(const edm::ParameterSet& iConfig):
-    probes_(iConfig.getParameter<edm::InputTag>("probes")),
+    probes_(consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("probes"))),
     doOverlapRemoval_(iConfig.getParameter<bool>("doOverlapRemoval")),
-    goodElectrons_(doOverlapRemoval_ ? iConfig.getParameter<edm::InputTag>("goodElectrons") : edm::InputTag("NONE")),
-    goodMuons_(doOverlapRemoval_ ? iConfig.getParameter<edm::InputTag>("goodMuons") : edm::InputTag("NONE")),
-    pfCandidates_(iConfig.getParameter<edm::InputTag>("pfCandidates")),
-    vertices_(iConfig.getParameter<edm::InputTag>("vertices")),
+    goodElectrons_(consumes<edm::View<reco::GsfElectron>>(doOverlapRemoval_ ? iConfig.getParameter<edm::InputTag>("goodElectrons") : edm::InputTag("NONE"))),
+    goodMuons_(consumes<edm::View<reco::Muon>>(doOverlapRemoval_ ? iConfig.getParameter<edm::InputTag>("goodMuons") : edm::InputTag("NONE"))),
+    pfCandidates_(consumes<edm::View<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("pfCandidates"))),
+    vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
     dzCut_(iConfig.getParameter<double>("dzCut")),
     photonPtMin_(iConfig.getParameter<double>("photonPtMin")),
     neutralHadPtMin_(iConfig.getParameter<double>("neutralHadPtMin"))
@@ -116,19 +116,19 @@ MuonMVAIsoVariables::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   // read input
   Handle<View<reco::Muon> > probes;
-  iEvent.getByLabel(probes_, probes);
+  iEvent.getByToken(probes_, probes);
 
   Handle<View<reco::GsfElectron> > goodElectrons;
   Handle<View<reco::Muon> >        goodMuons;
   if (doOverlapRemoval_) {
-      iEvent.getByLabel(goodMuons_,     goodMuons);
-      iEvent.getByLabel(goodElectrons_, goodElectrons);
+      iEvent.getByToken(goodMuons_,     goodMuons);
+      iEvent.getByToken(goodElectrons_, goodElectrons);
   }
 
   Handle<View<reco::PFCandidate> > pfCandidates;
   Handle<reco::VertexCollection  > vertices;
-  iEvent.getByLabel(pfCandidates_, pfCandidates);
-  iEvent.getByLabel(vertices_, vertices);
+  iEvent.getByToken(pfCandidates_, pfCandidates);
+  iEvent.getByToken(vertices_, vertices);
   const reco::Vertex &vtx = !vertices->empty() ? vertices->at(0) : reco::Vertex();
 
   View<reco::Muon>::const_iterator probe, endprobes=probes->end();

--- a/plugins/MuonMiniIso.cc
+++ b/plugins/MuonMiniIso.cc
@@ -37,8 +37,8 @@ private:
   virtual void produce(edm::Event&, const edm::EventSetup&);
 
   // ----------member data ---------------------------
-  const edm::InputTag probes_;    
-  const edm::InputTag pfCandidates_;
+  const edm::EDGetTokenT<edm::View<reco::Muon>> probes_;    
+  const edm::EDGetTokenT<edm::View<reco::PFCandidate>> pfCandidates_;
   double dRCandProbeVeto_;
   double dRCandSoftActivityCone_;
   double CandPtThreshold_;
@@ -66,8 +66,8 @@ private:
 // constructors and destructor
 //
 MuonMiniIso::MuonMiniIso(const edm::ParameterSet& iConfig):
-probes_(iConfig.getParameter<edm::InputTag>("probes")),
-pfCandidates_(iConfig.getParameter<edm::InputTag>("pfCandidates")),
+probes_(consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("probes"))),
+pfCandidates_(consumes<edm::View<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("pfCandidates"))),
 dRCandProbeVeto_(iConfig.getParameter<double>("dRCandProbeVeto")),
 dRCandSoftActivityCone_(iConfig.getParameter<double>("dRCandSoftActivityCone")),
 CandPtThreshold_(iConfig.getParameter<double>("CandPtThreshold"))
@@ -94,11 +94,11 @@ MuonMiniIso::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   // read input
   Handle<View<reco::Muon> > probes;
-  iEvent.getByLabel(probes_, probes);
+  iEvent.getByToken(probes_, probes);
 
   //Handle<View<reco::PFCandidate> > pfCandidates;
   Handle<PFCollection> pfCandidates;
-  iEvent.getByLabel(pfCandidates_, pfCandidates);
+  iEvent.getByToken(pfCandidates_, pfCandidates);
 
   View<reco::Muon>::const_iterator probe, endprobes=probes->end();
   PFCollection::const_iterator iP, beginpf = pfCandidates->begin(), endpf=pfCandidates->end();

--- a/plugins/MuonRadialIso.cc
+++ b/plugins/MuonRadialIso.cc
@@ -37,8 +37,8 @@ private:
   virtual void produce(edm::Event&, const edm::EventSetup&);
 
   // ----------member data ---------------------------
-  const edm::InputTag probes_;    
-  const edm::InputTag pfCandidates_;
+  const edm::EDGetTokenT<edm::View<reco::Muon>> probes_;    
+  const edm::EDGetTokenT<edm::View<reco::PFCandidate>> pfCandidates_;
 
   //edm::EDGetTokenT<PFCollection> tokenPFCandidates_;
 
@@ -66,8 +66,8 @@ private:
 // constructors and destructor
 //
 MuonRadialIso::MuonRadialIso(const edm::ParameterSet& iConfig):
-    probes_(iConfig.getParameter<edm::InputTag>("probes")),
-    pfCandidates_(iConfig.getParameter<edm::InputTag>("pfCandidates")),
+    probes_(consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("probes"))),
+    pfCandidates_(consumes<edm::View<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("pfCandidates"))),
     photonPtMin_(iConfig.getParameter<double>("photonPtMin")),
     neutralHadPtMin_(iConfig.getParameter<double>("neutralHadPtMin"))
 {
@@ -92,11 +92,11 @@ MuonRadialIso::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   // read input
   Handle<View<reco::Muon> > probes;
-  iEvent.getByLabel(probes_, probes);
+  iEvent.getByToken(probes_, probes);
 
   //Handle<View<reco::PFCandidate> > pfCandidates;
   Handle<PFCollection> pfCandidates;
-  iEvent.getByLabel(pfCandidates_, pfCandidates);
+  iEvent.getByToken(pfCandidates_, pfCandidates);
 
   View<reco::Muon>::const_iterator probe, endprobes=probes->end();
   PFCollection::const_iterator iP, beginpf = pfCandidates->begin(), endpf=pfCandidates->end();

--- a/plugins/NearbyMuonsInfo.cc
+++ b/plugins/NearbyMuonsInfo.cc
@@ -40,7 +40,7 @@ class NearbyMuonsInfo : public edm::EDProducer {
       virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
       virtual void beginRun(const edm::Run & iRun, const edm::EventSetup & iSetup);
     private:
-        edm::InputTag src_;
+        edm::EDGetTokenT<edm::View<reco::Candidate>> src_;
         PropagateToMuon prop1_, prop2_;
 
         /// Write a ValueMap<float> in the event
@@ -52,7 +52,7 @@ class NearbyMuonsInfo : public edm::EDProducer {
 };
 
 NearbyMuonsInfo::NearbyMuonsInfo(const edm::ParameterSet & iConfig) :
-    src_(iConfig.getParameter<edm::InputTag>("src")),
+    src_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("src"))),
     prop1_(iConfig.getParameter<edm::ParameterSet>("propM1")),
     prop2_(iConfig.getParameter<edm::ParameterSet>("propM2"))
 {
@@ -81,7 +81,7 @@ NearbyMuonsInfo::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
     using namespace std;
 
     Handle<View<reco::Candidate> > src;
-    iEvent.getByLabel(src_, src);
+    iEvent.getByToken(src_, src);
     edm::ESHandle<MagneticField> theMF;
     iSetup.get<IdealMagneticFieldRecord>().get(theMF);
 

--- a/plugins/ObjectCleanedMultiplicityCounter.cc
+++ b/plugins/ObjectCleanedMultiplicityCounter.cc
@@ -32,16 +32,16 @@ class ObjectCleanedMultiplicityCounter : public edm::EDProducer {
         virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
 
     private:
-        edm::InputTag pairs_;            
-        edm::InputTag objects_; 
+        edm::EDGetTokenT<edm::View<reco::Candidate>> pairs_;            
+        edm::EDGetTokenT<edm::View<T>> objects_; 
         StringCutObjectSelector<T,true> objCut_; // lazy parsing, to allow cutting on variables not in reco::Candidate class
         double objDR2Tag_, objDR2Probe_;
 };
 
 template<typename T>
 ObjectCleanedMultiplicityCounter<T>::ObjectCleanedMultiplicityCounter(const edm::ParameterSet & iConfig) :
-    pairs_(iConfig.getParameter<edm::InputTag>("pairs")),
-    objects_(iConfig.getParameter<edm::InputTag>("objects")),
+    pairs_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("pairs"))),
+    objects_(consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("objects"))),
     objCut_(iConfig.existsAs<std::string>("objectSelection") ? iConfig.getParameter<std::string>("objectSelection") : "", true),
     objDR2Tag_(std::pow(iConfig.getParameter<double>("minTagObjDR"),2)),
     objDR2Probe_(std::pow(iConfig.getParameter<double>("minProbeObjDR"),2))
@@ -63,8 +63,8 @@ ObjectCleanedMultiplicityCounter<T>::produce(edm::Event & iEvent, const edm::Eve
     // read input
     Handle<View<reco::Candidate> > pairs;
     Handle<View<T> > objects;
-    iEvent.getByLabel(pairs_,  pairs);
-    iEvent.getByLabel(objects_, objects);
+    iEvent.getByToken(pairs_,  pairs);
+    iEvent.getByToken(objects_, objects);
     
     // fill
     std::vector<const T *> selObjs;

--- a/plugins/RedefineMuonP4FromTrack.cc
+++ b/plugins/RedefineMuonP4FromTrack.cc
@@ -28,14 +28,14 @@ class RedefineMuonP4FromTrackT : public edm::EDProducer {
 
     private:
       enum TkType { TrackerTk, MuonTk, GlobalTk } ;
-      edm::InputTag src_;
+      edm::EDGetTokenT<edm::View<T>> src_;
       TkType        track_;
       
 };
 
 template<typename T>
 RedefineMuonP4FromTrackT<T>::RedefineMuonP4FromTrackT(const edm::ParameterSet & iConfig) :
-    src_(iConfig.getParameter<edm::InputTag>("src"))
+    src_(consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("src")))
 {
     std::string track = iConfig.getParameter<std::string>("track");
     if (track == "tracker" || track == "inner" || track == "silicon") track_ = TrackerTk;
@@ -52,7 +52,7 @@ RedefineMuonP4FromTrackT<T>::produce(edm::Event & iEvent, const edm::EventSetup 
     using namespace std;
 
     Handle<View<T> >      src;
-    iEvent.getByLabel(src_, src);
+    iEvent.getByToken(src_, src);
 
     auto_ptr<vector<T> >  out(new vector<T>());
     out->reserve(src->size());

--- a/plugins/ResonanceInefficiencyCreator.cc
+++ b/plugins/ResonanceInefficiencyCreator.cc
@@ -69,10 +69,10 @@ class ResonanceInefficiencyCreator : public edm::EDProducer {
         virtual void produce(edm::Event&, const edm::EventSetup&);
 
         /// The RECO objects
-        edm::InputTag src_;
+        edm::EDGetTokenT<edm::View<T>> src_;
 
         /// The Tags
-        edm::InputTag tags_;
+        edm::EDGetTokenT<edm::View<reco::Candidate>> tags_;
 
         /// Mass value and window
         double mass_, massMin_, massMax_;
@@ -97,8 +97,8 @@ class ResonanceInefficiencyCreator : public edm::EDProducer {
 
 template<typename T>
 ResonanceInefficiencyCreator<T>::ResonanceInefficiencyCreator(const edm::ParameterSet &iConfig) :
-    src_(iConfig.getParameter<edm::InputTag>("src")),
-    tags_(iConfig.getParameter<edm::InputTag>("tags")),
+    src_(consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("src"))),
+    tags_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("tags"))),
     mass_(iConfig.getParameter<double>("mass")),
     massMin_(iConfig.getParameter<double>("massMin")),
     massMax_(iConfig.getParameter<double>("massMax")),
@@ -146,10 +146,10 @@ void
 ResonanceInefficiencyCreator<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
     edm::Handle<edm::View<T> > src; 
-    iEvent.getByLabel(src_, src);
+    iEvent.getByToken(src_, src);
 
     edm::Handle<edm::View<reco::Candidate> > tags; 
-    iEvent.getByLabel(tags_, tags);
+    iEvent.getByToken(tags_, tags);
 
     CLHEP::HepRandomEngine& engine = rng_->getEngine( iEvent.streamID() );
 

--- a/python/common_variables_cff.py
+++ b/python/common_variables_cff.py
@@ -96,9 +96,9 @@ L1Variables = cms.PSet(
     l1pt = cms.string("? userCand('muonL1Info').isNull ? 0 : userCand('muonL1Info').pt"),
     l1q  = cms.string("userInt('muonL1Info:quality')"),
     l1dr = cms.string("userFloat('muonL1Info:deltaR')"),
-    l1ptByQ = cms.string("? userCand('muonL1Info:ByQ').isNull ? 0 : userCand('muonL1Info:ByQ').pt"),
-    l1qByQ  = cms.string("userInt('muonL1Info:qualityByQ')"),
-    l1drByQ = cms.string("userFloat('muonL1Info:deltaRByQ')"),
+    #l1ptByQ = cms.string("? userCand('muonL1Info:ByQ').isNull ? 0 : userCand('muonL1Info:ByQ').pt"),
+    #l1qByQ  = cms.string("userInt('muonL1Info:qualityByQ')"),
+    #l1drByQ = cms.string("userFloat('muonL1Info:deltaRByQ')"),
 )
 L2Variables = cms.PSet(
     l2pt  = cms.string("? triggerObjectMatchesByCollection('hltL2MuonCandidates').empty() ? 0 : triggerObjectMatchesByCollection('hltL2MuonCandidates').at(0).pt"),


### PR DESCRIPTION
- getByToken migration
  - disable `ComputeL1HLTPrescales`; somebody should take care of migrating it to 7_6_X properly
  - disable l1 matchings ordered by quality, since they are not available. Again, if needed somebody should re-implement them
