### PR TITLE
Get it run in 76X

### DIFF
--- a/plugins/MuonDxyPVdzmin.cc
+++ b/plugins/MuonDxyPVdzmin.cc
@@ -42,6 +42,8 @@ private:
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<edm::View<reco::Muon>> probes_;    
+  const edm::EDGetTokenT<std::vector<reco::Vertex>> vertexes_;    
+  const edm::EDGetTokenT<reco::BeamSpot> bs_;    
 };
 
 //
@@ -57,8 +59,9 @@ private:
 // constructors and destructor
 //
 MuonDxyPVdzmin::MuonDxyPVdzmin(const edm::ParameterSet& iConfig):
-probes_(consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("probes")))
-
+probes_(consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("probes"))),
+vertexes_(consumes<std::vector<reco::Vertex>>(edm::InputTag("offlinePrimaryVertices"))),
+bs_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot")))
 {
   produces<edm::ValueMap<float> >("dxyBS");
   produces<edm::ValueMap<float> >("dxyPVdzmin");
@@ -90,10 +93,10 @@ MuonDxyPVdzmin::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.getByToken(probes_,  probes);
   
   edm::Handle<std::vector<reco::Vertex> > primaryVerticesHandle;
-  iEvent.getByLabel("offlinePrimaryVertices", primaryVerticesHandle);
+  iEvent.getByToken(vertexes_, primaryVerticesHandle);
       
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  iEvent.getByLabel("offlineBeamSpot" ,recoBeamSpotHandle);
+  iEvent.getByToken(bs_,recoBeamSpotHandle);
   reco::BeamSpot bs = *recoBeamSpotHandle;
   math::XYZPoint BSPosition;
   BSPosition = bs.position();

--- a/plugins/MuonMiniIso.cc
+++ b/plugins/MuonMiniIso.cc
@@ -38,7 +38,7 @@ private:
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<edm::View<reco::Muon>> probes_;    
-  const edm::EDGetTokenT<edm::View<reco::PFCandidate>> pfCandidates_;
+  const edm::EDGetTokenT<PFCollection> pfCandidates_;
   double dRCandProbeVeto_;
   double dRCandSoftActivityCone_;
   double CandPtThreshold_;
@@ -67,7 +67,7 @@ private:
 //
 MuonMiniIso::MuonMiniIso(const edm::ParameterSet& iConfig):
 probes_(consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("probes"))),
-pfCandidates_(consumes<edm::View<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("pfCandidates"))),
+pfCandidates_(consumes<PFCollection>(iConfig.getParameter<edm::InputTag>("pfCandidates"))),
 dRCandProbeVeto_(iConfig.getParameter<double>("dRCandProbeVeto")),
 dRCandSoftActivityCone_(iConfig.getParameter<double>("dRCandSoftActivityCone")),
 CandPtThreshold_(iConfig.getParameter<double>("CandPtThreshold"))

--- a/plugins/MuonRadialIso.cc
+++ b/plugins/MuonRadialIso.cc
@@ -38,7 +38,7 @@ private:
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<edm::View<reco::Muon>> probes_;    
-  const edm::EDGetTokenT<edm::View<reco::PFCandidate>> pfCandidates_;
+  const edm::EDGetTokenT<PFCollection> pfCandidates_;
 
   //edm::EDGetTokenT<PFCollection> tokenPFCandidates_;
 
@@ -67,7 +67,7 @@ private:
 //
 MuonRadialIso::MuonRadialIso(const edm::ParameterSet& iConfig):
     probes_(consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("probes"))),
-    pfCandidates_(consumes<edm::View<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("pfCandidates"))),
+    pfCandidates_(consumes<PFCollection>(iConfig.getParameter<edm::InputTag>("pfCandidates"))),
     photonPtMin_(iConfig.getParameter<double>("photonPtMin")),
     neutralHadPtMin_(iConfig.getParameter<double>("neutralHadPtMin"))
 {

--- a/test/jpsi/tp_from_aod_simple_Data.py
+++ b/test/jpsi/tp_from_aod_simple_Data.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+import subprocess
+
 process = cms.Process("TagProbe")
 
 process.load('Configuration.StandardSequences.Services_cff')
@@ -18,6 +20,7 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 
 # process.Tracer = cms.Service('Tracer')
+datafile = open('Run2015D_Charmonium_AOD_16Dec2015-v1_run260627.txt', 'r')
 
 import os
 if   "CMSSW_5_3_" in os.environ['CMSSW_VERSION']:
@@ -59,6 +62,12 @@ elif "CMSSW_7_4_" in os.environ['CMSSW_VERSION']:
         '/store/data/Run2015B/Charmonium/AOD/PromptReco-v1/000/251/252/00000/642ACBD2-A127-E511-A59E-02163E0123F1.root',
         '/store/data/Run2015B/Charmonium/AOD/PromptReco-v1/000/251/252/00000/F24C3492-9627-E511-AEC5-02163E011C7F.root'
     ]
+elif "CMSSW_7_6_" in os.environ['CMSSW_VERSION']:
+
+    process.GlobalTag.globaltag = cms.string('76X_dataRun2_v15')
+    process.source.fileNames = cms.untracked.vstring(datafile.read().splitlines())
+    print process.source.fileNames
+
 else: raise RuntimeError, "Unknown CMSSW version %s" % os.environ['CMSSW_VERSION']
 
 

--- a/test/jpsi/tp_from_aod_simple_MC.py
+++ b/test/jpsi/tp_from_aod_simple_MC.py
@@ -5,7 +5,7 @@ process = cms.Process("TagProbe")
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
-process.MessageLogger.cerr.FwkReport.reportEvery = 10
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
 
 process.source = cms.Source("PoolSource", 
     fileNames = cms.untracked.vstring(),
@@ -40,6 +40,14 @@ elif "CMSSW_7_4_" in os.environ['CMSSW_VERSION']:
     process.source.fileNames = [
         'file:data2015/RelValBoostedJPsi_7_3_0_pre1/Reference_PU35/RECO_1.root',
     ]
+elif "CMSSW_7_6_" in os.environ['CMSSW_VERSION']:
+    process.GlobalTag.globaltag = cms.string('76X_mcRun2_asymptotic_v12')
+    process.source.fileNames = [
+        '/store/mc/RunIIFall15DR76/JpsiToMuMu_JpsiPt8_TuneCUEP8M1_13TeV-pythia8/AODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/00000/007508E4-EDB4-E511-AA41-B083FED00118.root',
+        '/store/mc/RunIIFall15DR76/JpsiToMuMu_JpsiPt8_TuneCUEP8M1_13TeV-pythia8/AODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/00000/0256E6F9-2FB5-E511-9570-002590FD5A52.root',
+        '/store/mc/RunIIFall15DR76/JpsiToMuMu_JpsiPt8_TuneCUEP8M1_13TeV-pythia8/AODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/00000/02916244-E3B4-E511-8842-0026189438FA.root',
+    ]
+    
 else: raise RuntimeError, "Unknown CMSSW version %s" % os.environ['CMSSW_VERSION']
 
 ## SELECT WHAT DATASET YOU'RE RUNNING ON

--- a/test/zmumu/tp_from_aod_Data.py
+++ b/test/zmumu/tp_from_aod_Data.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 import subprocess
-#dataSummary = open('dataSummary.txt', 'w')
 
 process = cms.Process("TagProbe")
 
@@ -19,6 +18,8 @@ process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 process.load("Configuration.StandardSequences.Reconstruction_cff")
+
+datafile = open('Run2015D_SingleMuon_AOD_16Dec2015-v1_run260627.txt', 'r')
 
 import os
 if "CMSSW_7_4_" in os.environ['CMSSW_VERSION']:
@@ -47,6 +48,12 @@ if "CMSSW_7_4_" in os.environ['CMSSW_VERSION']:
     # to add following runs: 251491, 251493, 251496, ..., 251500 
     print process.source.fileNames
     #print process.source.fileNames, dataSummary
+
+if "CMSSW_7_6_" in os.environ['CMSSW_VERSION']:
+    
+    process.GlobalTag.globaltag = cms.string('76X_dataRun2_v15')
+    process.source.fileNames = cms.untracked.vstring(datafile.read().splitlines())
+    print process.source.fileNames
 
 else: raise RuntimeError, "Unknown CMSSW version %s" % os.environ['CMSSW_VERSION']
 
@@ -566,4 +573,4 @@ if TRIGGER == "SingleMu":
        process.fakeRateZPlusProbe,
     ])
 
-process.TFileService = cms.Service("TFileService", fileName = cms.string("tnpZ_Data_PromptReco.root"))
+process.TFileService = cms.Service("TFileService", fileName = cms.string("tnpZ_Data.root"))

--- a/test/zmumu/tp_from_aod_MC.py
+++ b/test/zmumu/tp_from_aod_MC.py
@@ -10,7 +10,7 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.source = cms.Source("PoolSource", 
     fileNames = cms.untracked.vstring(),
 )
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )    
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1))
 
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
@@ -18,18 +18,17 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condD
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 
 import os
-if "CMSSW_7_4_" in os.environ['CMSSW_VERSION']:
-    process.GlobalTag.globaltag = cms.string('MCRUN2_74_V9')
+if "CMSSW_7_6_" in os.environ['CMSSW_VERSION']:
+    process.GlobalTag.globaltag = cms.string('76X_mcRun2_asymptotic_v12')
     process.source.fileNames = [
-        # '/store/relval/CMSSW_7_4_6/RelValZMM_13/GEN-SIM-RECO/PU50ns_MCRUN2_74_V8-v2/00000/0CE0AB97-2E1A-E511-A324-0025905A607E.root',
-        # '/store/relval/CMSSW_7_4_6/RelValZMM_13/GEN-SIM-RECO/PU50ns_MCRUN2_74_V8-v2/00000/0E3FF274-2C1A-E511-9FC5-0025905A60D2.root',
-        # '/store/relval/CMSSW_7_4_6/RelValZMM_13/GEN-SIM-RECO/PU50ns_MCRUN2_74_V8-v2/00000/68042E12-471B-E511-B16E-0025905A60B4.root',
-        # '/store/relval/CMSSW_7_4_6/RelValZMM_13/GEN-SIM-RECO/PU50ns_MCRUN2_74_V8-v2/00000/860D8B15-251A-E511-B97A-0025905A612C.root',
-        # '/store/relval/CMSSW_7_4_6/RelValZMM_13/GEN-SIM-RECO/PU50ns_MCRUN2_74_V8-v2/00000/8A3792A9-141B-E511-8931-0025905A6084.root',
-        # '/store/relval/CMSSW_7_4_6/RelValZMM_13/GEN-SIM-RECO/PU50ns_MCRUN2_74_V8-v2/00000/A2D65BC4-141B-E511-8A1A-002618943875.root',
-        # '/store/relval/CMSSW_7_4_6/RelValZMM_13/GEN-SIM-RECO/PU50ns_MCRUN2_74_V8-v2/00000/B4DFF255-4A1A-E511-81FA-0025905A48E4.root',
-        # '/store/relval/CMSSW_7_4_6/RelValZMM_13/GEN-SIM-RECO/PU50ns_MCRUN2_74_V8-v2/00000/B6B36157-4A1A-E511-9FFA-003048FF86CA.root'
-        'root://cmsxrootd.fnal.gov//store/mc/RunIISpring15DR74/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/AODSIM/Asympt25ns_MCRUN2_74_V9-v3/10000/383E068B-D013-E511-838D-002590D9D8AA.root'
+      '/store/relval/CMSSW_7_6_2/RelValZMM_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v12-v1/00000/56C948BE-CD9C-E511-9349-002590596468.root',
+      '/store/relval/CMSSW_7_6_2/RelValZMM_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v12-v1/00000/56F71722-CC9C-E511-9FCF-0CC47A4D7668.root',
+      '/store/relval/CMSSW_7_6_2/RelValZMM_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v12-v1/00000/6090AA28-CC9C-E511-931E-003048FFD756.root',
+      '/store/relval/CMSSW_7_6_2/RelValZMM_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v12-v1/00000/942C06FC-CC9C-E511-BD1B-0CC47A4D765E.root',
+      '/store/relval/CMSSW_7_6_2/RelValZMM_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v12-v1/00000/A68E95F5-CF9C-E511-9F00-0CC47A4D7668.root',
+      '/store/relval/CMSSW_7_6_2/RelValZMM_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v12-v1/00000/CCD157ED-CA9C-E511-A54E-0CC47A78A446.root',
+      '/store/relval/CMSSW_7_6_2/RelValZMM_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v12-v1/00000/F44985F2-CA9C-E511-A9F3-0CC47A4C8E2A.root',
+      '/store/relval/CMSSW_7_6_2/RelValZMM_13/GEN-SIM-RECO/PU25ns_76X_mcRun2_asymptotic_v12-v1/00000/F453A13A-D09C-E511-9A18-0CC47A4D765E.root',
     ]
 else: raise RuntimeError, "Unknown CMSSW version %s" % os.environ['CMSSW_VERSION']
 
@@ -334,6 +333,7 @@ process.tpTreeSta = process.tpTree.clone(
         pt = cms.string("pt"),
         eta = cms.string("eta"),
         phi = cms.string("phi"),
+        vz = cms.string("vz"), #Z point of closest approach of the track to the beam line 
         nVertices = cms.InputTag("nverticesModule"),
         combRelIso = cms.string("(isolationR03.emEt + isolationR03.hadEt + isolationR03.sumPt)/pt"),
         chargedHadIso04 = cms.string("pfIsolationR04().sumChargedHadronPt"),

--- a/test/zmumu/tp_from_aod_MC.py
+++ b/test/zmumu/tp_from_aod_MC.py
@@ -467,6 +467,7 @@ if True: # turn on for tracking efficiency using gen particles as probe
         process.genToTkMatch + process.genToTkMatchNoZ +
         process.genToTkMatch0 + process.genToTkMatchNoZ0 +
         process.probeMuonsMCMatchGen +
+        process.nverticesModule +
         process.tpTreeGen
     )
 
@@ -530,6 +531,7 @@ if True: # turn on for tracking efficiency using L1 seeds
         process.l1ToTkMatch + process.l1ToTkMatchNoZ +
         process.l1ToTkMatch0 + process.l1ToTkMatchNoZ0 +
         process.probeMuonsMCMatchL1 +
+        process.nverticesModule +
         process.tpTreeL1
     )
 


### PR DESCRIPTION
I have modified some EDGetToken in order to get the code run in 76X. 
Tested on MC.
Moreover, now the efficiency can be also computed as a function of the z point of closest approach of the track to the beam line.

_Note: on CMSSW 7_6_3 or earlier, you also need to do `git cms-merge-topic ebrondol:FixTnP_76X` to get a fix to the muon IsoDeposit producer_
