### PR TITLE
Adding additional info to TnP tags (for now just inst. lumi.)

### DIFF
--- a/plugins/AdditionalEventInfo.cc
+++ b/plugins/AdditionalEventInfo.cc
@@ -1,0 +1,123 @@
+//
+// $Id: AdditionalEventInfo.cc,v 1.1 2015/08/23 13:49:16 battilan Exp $
+//
+
+/**
+  \class    AdditionalEventInfo 
+  \brief    Adds bx, orbit and inst lumi info (the last from scalers)
+            
+  \Author   Carlo Battilana
+  \version  $Id: AdditionalEventInfo.cc,v 1.1 2015/01/06 10:41:10 battilan Exp $
+*/
+
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+
+#include "DataFormats/Scalers/interface/LumiScalers.h"
+#include "DataFormats/Luminosity/interface/LumiDetails.h"
+
+#include "DataFormats/Candidate/interface/CompositeCandidate.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+
+
+
+class AdditionalEventInfo : public edm::EDProducer
+{
+  
+public:
+
+  explicit AdditionalEventInfo(const edm::ParameterSet & iConfig);
+  virtual ~AdditionalEventInfo() { }
+
+  virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) final;
+
+private:
+
+  edm::EDGetTokenT<LumiScalersCollection> m_lumiScalerTag;
+  edm::EDGetTokenT<edm::View<reco::Candidate> > m_pairTag;
+  
+  /// Write a ValueMap<T> in the event
+  template<typename T> void writeValueMap(edm::Event &ev, const edm::Handle<edm::View<reco::Candidate> > & handle,
+					  const std::vector<T> & values, const std::string    & label) const ;
+  
+};
+
+AdditionalEventInfo::AdditionalEventInfo(const edm::ParameterSet & iConfig) :
+  m_lumiScalerTag(consumes<LumiScalersCollection>(iConfig.getParameter<edm::InputTag>("lumiScalerTag"))),
+  m_pairTag(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("pairTag")))
+{
+  
+  // produces<edm::ValueMap<ULong64_t> >("orbit");
+  produces<edm::ValueMap<float> >("instLumi");
+
+}
+
+void AdditionalEventInfo::produce(edm::Event & ev, const edm::EventSetup & iSetup)
+{
+
+  // ULong64_t orbit = 0;
+  float instLumi = -999.;
+
+  if (ev.isRealData())
+    {
+      // orbit = ev.orbitNumber();
+      
+      if (!m_lumiScalerTag.isUninitialized())
+	{
+	  edm::Handle<LumiScalersCollection> lumiScaler;
+	  ev.getByToken(m_lumiScalerTag, lumiScaler);
+	  
+	  if (lumiScaler->begin() != lumiScaler->end())
+	    instLumi= lumiScaler->begin()->instantLumi();
+	} 
+      else
+	{
+	  throw cms::Exception("CorruptData") << 
+	    "[AdditionalEventInfo::produce] AdditionalEventInfo requires a valid LumiScalerCollecion InpuTag \n";
+	}
+    } 
+  
+  edm::Handle<edm::View<reco::Candidate> > pairs;
+  ev.getByToken(m_pairTag, pairs);
+
+  size_t n = pairs->size();
+  
+  // std::vector<ULong64_t> orbits(n,0);
+  std::vector<float> instLumis(n,0.);
+  
+  for (size_t iPair = 0; iPair < n; ++iPair)
+    {
+      const reco::Candidate & pair = (*pairs)[iPair];
+      if (pair.numberOfDaughters() != 2) throw cms::Exception("CorruptData") << 
+					   "[AdditionalEventInfo::produce] AdditionalEventInfo should be used on composite candidates with two daughters, this one has " << pair.numberOfDaughters() << "\n";
+      
+      //orbits[iPair]    = orbit;
+      instLumis[iPair] = instLumi;
+    }
+
+  // writeValueMap<ULong64_t>(ev, pairs, orbits, "orbit");
+  writeValueMap<float>(ev, pairs, instLumis, "instLumi");
+
+}
+
+template<typename T> void AdditionalEventInfo::writeValueMap(edm::Event & ev, const edm::Handle<edm::View<reco::Candidate> > & handle,
+							     const std::vector<T> & values, const std::string & label) const 
+{
+  
+  std::auto_ptr<edm::ValueMap<T> > valMap(new edm::ValueMap<T>());
+  typename edm::ValueMap<T>::Filler filler(*valMap);
+  filler.insert(handle, values.begin(), values.end());
+  filler.fill();
+  ev.put(valMap, label);
+  
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(AdditionalEventInfo);

--- a/plugins/AdditionalEventInfo.cc
+++ b/plugins/AdditionalEventInfo.cc
@@ -40,7 +40,7 @@ public:
 private:
 
   edm::EDGetTokenT<LumiScalersCollection> m_lumiScalerTag;
-  edm::EDGetTokenT<edm::View<reco::Candidate> > m_pairTag;
+  edm::EDGetTokenT<edm::View<reco::Candidate> > m_muonTag;
   
   /// Write a ValueMap<T> in the event
   template<typename T> void writeValueMap(edm::Event &ev, const edm::Handle<edm::View<reco::Candidate> > & handle,
@@ -50,7 +50,7 @@ private:
 
 AdditionalEventInfo::AdditionalEventInfo(const edm::ParameterSet & iConfig) :
   m_lumiScalerTag(consumes<LumiScalersCollection>(iConfig.getParameter<edm::InputTag>("lumiScalerTag"))),
-  m_pairTag(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("pairTag")))
+  m_muonTag(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("muonTag")))
 {
   
   // produces<edm::ValueMap<ULong64_t> >("orbit");
@@ -79,30 +79,21 @@ void AdditionalEventInfo::produce(edm::Event & ev, const edm::EventSetup & iSetu
       else
 	{
 	  throw cms::Exception("CorruptData") << 
-	    "[AdditionalEventInfo::produce] AdditionalEventInfo requires a valid LumiScalerCollecion InpuTag \n";
+	    "[AdditionalEventInfo::produce] AdditionalEventInfo requires a valid LumiScalerCollecion InpuTag" << std::endl;
 	}
     } 
   
-  edm::Handle<edm::View<reco::Candidate> > pairs;
-  ev.getByToken(m_pairTag, pairs);
+  edm::Handle<edm::View<reco::Candidate> > muons;
+  ev.getByToken(m_muonTag, muons);
 
-  size_t n = pairs->size();
+  size_t n = muons->size();
   
-  // std::vector<ULong64_t> orbits(n,0);
-  std::vector<float> instLumis(n,0.);
+  // std::vector<ULong64_t> orbits(n, orbit);
+  std::vector<float> instLumis(n, instLumi);
   
-  for (size_t iPair = 0; iPair < n; ++iPair)
-    {
-      const reco::Candidate & pair = (*pairs)[iPair];
-      if (pair.numberOfDaughters() != 2) throw cms::Exception("CorruptData") << 
-					   "[AdditionalEventInfo::produce] AdditionalEventInfo should be used on composite candidates with two daughters, this one has " << pair.numberOfDaughters() << "\n";
-      
-      //orbits[iPair]    = orbit;
-      instLumis[iPair] = instLumi;
-    }
 
-  // writeValueMap<ULong64_t>(ev, pairs, orbits, "orbit");
-  writeValueMap<float>(ev, pairs, instLumis, "instLumi");
+  // writeValueMap<ULong64_t>(ev, muons, orbits, "orbit");
+  writeValueMap<float>(ev, muons, instLumis, "instLumi");
 
 }
 

--- a/python/common_modules_cff.py
+++ b/python/common_modules_cff.py
@@ -213,6 +213,11 @@ splitTrackTagger = cms.EDProducer("NearbyCandCountComputer",
 )
 #numberOfLostHits('MISSING_INNER_HITS')
 
+addEventInfo = cms.EDProducer("AdditionalEventInfo",
+    pairTag= cms.InputTag("tpPairs"),
+    lumiScalerTag= cms.InputTag("scalersRawToDigi")
+)
+
 l1rate = cms.EDProducer("ComputeL1TriggerRate",
     probes = cms.InputTag("tagMuons"),
     scalers = cms.InputTag("scalersRawToDigi"),

--- a/python/common_modules_cff.py
+++ b/python/common_modules_cff.py
@@ -214,7 +214,7 @@ splitTrackTagger = cms.EDProducer("NearbyCandCountComputer",
 #numberOfLostHits('MISSING_INNER_HITS')
 
 addEventInfo = cms.EDProducer("AdditionalEventInfo",
-    pairTag= cms.InputTag("tpPairs"),
+    muonTag= cms.InputTag("tagMuons"),
     lumiScalerTag= cms.InputTag("scalersRawToDigi")
 )
 

--- a/test/zmumu/tp_from_aod_Data.py
+++ b/test/zmumu/tp_from_aod_Data.py
@@ -227,6 +227,7 @@ process.tpTree = cms.EDAnalyzer("TagProbeFitTreeProducer",
         bx     = cms.InputTag("l1rate","bx"),
         #mu17ps = cms.InputTag("l1hltprescale","HLTMu17TotalPrescale"), 
         #mu8ps  = cms.InputTag("l1hltprescale","HLTMu8TotalPrescale"), 
+        instLumi = cms.InputTag("addEventInfo", "instLumi"),
     ),
     tagFlags = cms.PSet(HighPtTriggerFlags,HighPtTriggerFlagsDebug),
     pairVariables = cms.PSet(
@@ -243,7 +244,6 @@ process.tpTree = cms.EDAnalyzer("TagProbeFitTreeProducer",
         newTuneP_probe_sigmaPtOverPt = cms.InputTag("newTunePVals", "ptRelError"),
         newTuneP_probe_trackType     = cms.InputTag("newTunePVals", "trackType"),
         newTuneP_mass                = cms.InputTag("newTunePVals", "mass"),
-        instLumi = cms.InputTag("addEventInfo", "instLumi"),
     ),
     pairFlags = cms.PSet(
         BestZ = cms.InputTag("bestPairByZMass"),
@@ -292,11 +292,11 @@ process.tnpSimpleSequence = cms.Sequence(
     process.njets30Module +
     process.extraProbeVariablesSeq +
     process.probeMultiplicities + 
+    process.addEventInfo +
     process.l1rate +
     #process.l1hltprescale + 
     process.bestPairByZMass + 
     process.newTunePVals +
-    process.addEventInfo +
     process.muonDxyPVdzminTags +
     process.tpTree
 )
@@ -375,6 +375,7 @@ process.tpTreeSta = process.tpTree.clone(
         combRelIsoPF04dBeta = IsolationVariables.combRelIsoPF04dBeta,
         l1rate = cms.InputTag("l1rate"),
         bx     = cms.InputTag("l1rate","bx"),
+        instLumi = cms.InputTag("addEventInfo", "instLumi"),
     ),
     pairVariables = cms.PSet(
         nJets30 = cms.InputTag("njets30ModuleSta"),
@@ -396,6 +397,7 @@ process.tnpSimpleSequenceSta = cms.Sequence(
     process.nverticesModule +
     process.staToTkMatchSequenceZ +
     process.njets30ModuleSta +
+    process.addEventInfo +
     process.l1rate +
     process.tpTreeSta
 )

--- a/test/zmumu/tp_from_aod_Data.py
+++ b/test/zmumu/tp_from_aod_Data.py
@@ -243,6 +243,7 @@ process.tpTree = cms.EDAnalyzer("TagProbeFitTreeProducer",
         newTuneP_probe_sigmaPtOverPt = cms.InputTag("newTunePVals", "ptRelError"),
         newTuneP_probe_trackType     = cms.InputTag("newTunePVals", "trackType"),
         newTuneP_mass                = cms.InputTag("newTunePVals", "mass"),
+        instLumi = cms.InputTag("addEventInfo", "instLumi"),
     ),
     pairFlags = cms.PSet(
         BestZ = cms.InputTag("bestPairByZMass"),
@@ -295,6 +296,7 @@ process.tnpSimpleSequence = cms.Sequence(
     #process.l1hltprescale + 
     process.bestPairByZMass + 
     process.newTunePVals +
+    process.addEventInfo +
     process.muonDxyPVdzminTags +
     process.tpTree
 )


### PR DESCRIPTION
This PR adds to TnP pairs the information of instantaneous luminosity from scalers.
It was used to for commissioning (e.g. check strip hit inefficiencies and perform HLT studies) back in 74X, but was never merged into the official repository.
For now inst. lumi. information is added just to muon ID "tpTree".
Though not strictly necessary for SF computation we though of sending the PR, so that code gets integrated.
@gpetruc if you think this module is redundant or you have any suggestion about its implementation please comment.
