### PR TITLE
Compute MET and MT for tags and probes

### DIFF
--- a/plugins/MuonMetMT.cc
+++ b/plugins/MuonMetMT.cc
@@ -1,0 +1,97 @@
+// system include files
+#include <memory>
+#include <cmath>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/METReco/interface/MET.h"
+
+//
+// class declaration
+//
+
+class MuonMetMT : public edm::EDProducer {
+public:
+
+  typedef edm::View<reco::MET> METColl;
+
+  explicit MuonMetMT(const edm::ParameterSet&);
+  ~MuonMetMT();
+
+private:
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+
+  const edm::EDGetTokenT<edm::View<reco::Muon>> probes_;    
+  const edm::EDGetTokenT<METColl> pfMet_;
+
+  template<typename Hand, typename T>
+  void storeMap(edm::Event &iEvent, const Hand & handle, const std::vector<T> & values, const std::string    & label) const ; 
+};
+
+MuonMetMT::MuonMetMT(const edm::ParameterSet& iConfig):
+probes_(consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("probes"))),
+pfMet_(consumes<METColl>(iConfig.getParameter<edm::InputTag>("met")))
+{
+  produces<edm::ValueMap<float> >("met");
+  produces<edm::ValueMap<float> >("mt");
+}
+
+
+MuonMetMT::~MuonMetMT()
+{
+}
+
+void
+MuonMetMT::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  using namespace edm;
+
+  Handle<View<reco::Muon> > probes;
+  iEvent.getByToken(probes_, probes);
+
+  Handle<METColl> mets;
+  iEvent.getByToken(pfMet_, mets);
+  const auto & met = mets->front();
+
+  unsigned int n = probes->size();
+  std::vector<float> vmet(n,met.pt());
+  std::vector<float> vmt(n,0);
+
+  unsigned int imu = 0;
+  for (auto probe = probes->begin(); imu < n; ++probe, ++imu) {
+    const reco::Muon &mu = *probe;
+    vmt[imu] = std::sqrt(2 * mu.pt() * met.pt() * ( 1 - std::cos(mu.phi()-met.phi()) ) );
+  }
+
+  storeMap(iEvent, probes, vmet, "met");
+  storeMap(iEvent, probes, vmt,  "mt");
+}
+
+template<typename Hand, typename T>
+void
+MuonMetMT::storeMap(edm::Event &iEvent,
+const Hand & handle,
+const std::vector<T> & values,
+const std::string    & label) const {
+  using namespace edm; using namespace std;
+  auto_ptr<ValueMap<T> > valMap(new ValueMap<T>());
+  typename edm::ValueMap<T>::Filler filler(*valMap);
+  filler.insert(handle, values.begin(), values.end());
+  filler.fill();
+  iEvent.put(valMap, label);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(MuonMetMT);

--- a/python/common_modules_cff.py
+++ b/python/common_modules_cff.py
@@ -243,3 +243,14 @@ goodGenMuons = cms.EDFilter("GenParticleSelector",
     cut = cms.string("abs(pdgId) == 13 && pt > 3 && abs(eta) < 2.4 && status == 1 && isPromptFinalState")
 )
 
+############## 
+## MET & MT 
+#############
+tagMetMt = cms.EDProducer("MuonMetMT",
+    probes = cms.InputTag("tagMuons"),
+    met = cms.InputTag("pfMet"),
+)
+probeMetMt = cms.EDProducer("MuonMetMT",
+    probes = cms.InputTag("probeMuons"),
+    met = cms.InputTag("pfMet"),
+)

--- a/test/treeSync.cxx
+++ b/test/treeSync.cxx
@@ -34,6 +34,7 @@
 #include <iomanip>
 #include <algorithm>
 #include <cassert>
+#include <Rtypes.h>
 
 /// utility: deltaPhi (unsigned)
 inline float dphi(float phi1, float phi2) {
@@ -52,7 +53,7 @@ struct Item {
         tag_pt(tagpt), tag_eta(tageta), tag_phi(tagphi), probe_pt(probept), probe_eta(probeeta), probe_phi(probephi),
         count(1) {}
 
-    unsigned int event; 
+    ULong64_t event; 
     float tag_pt, tag_eta, tag_phi, probe_pt, probe_eta, probe_phi; 
     mutable unsigned int count; 
 
@@ -379,7 +380,7 @@ int main(int argc, char **argv) {
 
         if (nshared1 == nshared2) break;
 
-        std::cout << "Swaping trees before repeating." << std::endl;
+        std::cout << "Swapping trees before repeating." << std::endl;
         std::swap(t1,t2);
         std::swap(f1,f2);
         std::swap(ok1,ok2);

--- a/test/zmumu/tp_from_aod_Data.py
+++ b/test/zmumu/tp_from_aod_Data.py
@@ -199,6 +199,7 @@ process.tpTree = cms.EDAnalyzer("TagProbeFitTreeProducer",
         miniIsoPhotons = cms.InputTag("muonMiniIsoPhotons","miniIso"),
         activity_miniIsoPhotons = cms.InputTag("muonMiniIsoPhotons","activity"),
         nSplitTk  = cms.InputTag("splitTrackTagger"),
+        mt  = cms.InputTag("probeMetMt","mt"),
     ),
     flags = cms.PSet(
        TrackQualityFlags,
@@ -235,6 +236,8 @@ process.tpTree = cms.EDAnalyzer("TagProbeFitTreeProducer",
         #mu17ps = cms.InputTag("l1hltprescale","HLTMu17TotalPrescale"), 
         #mu8ps  = cms.InputTag("l1hltprescale","HLTMu8TotalPrescale"), 
         instLumi = cms.InputTag("addEventInfo", "instLumi"),
+        met = cms.InputTag("tagMetMt","met"),
+        mt  = cms.InputTag("tagMetMt","mt"),
     ),
     tagFlags = cms.PSet(HighPtTriggerFlags,HighPtTriggerFlagsDebug),
     pairVariables = cms.PSet(
@@ -283,6 +286,7 @@ process.extraProbeVariablesSeq = cms.Sequence(
     process.mvaIsoVariablesSeq * process.mvaIsoVariablesTag * process.radialIso +
     process.splitTrackTagger +
     process.muonDxyPVdzmin + 
+    process.probeMetMt + process.tagMetMt +
     process.miniIsoSeq +
     # process.ak4PFCHSJetsL1L2L3 +
     process.ak4PFCHSL1FastL2L3CorrectorChain * process.jetAwareCleaner +

--- a/test/zmumu/tp_from_aod_MC.py
+++ b/test/zmumu/tp_from_aod_MC.py
@@ -155,6 +155,7 @@ process.tpTree = cms.EDAnalyzer("TagProbeFitTreeProducer",
         miniIsoPhotons = cms.InputTag("muonMiniIsoPhotons","miniIso"), 
         activity_miniIsoPhotons = cms.InputTag("muonMiniIsoPhotons","activity"), 
         nSplitTk  = cms.InputTag("splitTrackTagger"),
+        mt  = cms.InputTag("probeMetMt","mt"),
     ),
     flags = cms.PSet(
        TrackQualityFlags,
@@ -186,6 +187,8 @@ process.tpTree = cms.EDAnalyzer("TagProbeFitTreeProducer",
         dzPV = cms.InputTag("muonDxyPVdzminTags","dzPV"),
         radialIso = cms.InputTag("radialIso"), 
         nSplitTk  = cms.InputTag("splitTrackTagger"),
+        met = cms.InputTag("tagMetMt","met"),
+        mt  = cms.InputTag("tagMetMt","mt"),
     ),
     tagFlags = cms.PSet(HighPtTriggerFlags,HighPtTriggerFlagsDebug),
     pairVariables = cms.PSet(
@@ -242,6 +245,7 @@ process.extraProbeVariablesSeq = cms.Sequence(
     process.mvaIsoVariablesSeq * process.mvaIsoVariablesTag * process.radialIso +
     process.splitTrackTagger +
     process.muonDxyPVdzmin + 
+    process.probeMetMt + process.tagMetMt +
     process.miniIsoSeq +
     # process.ak4PFCHSJetsL1L2L3 +
     process.ak4PFCHSL1FastL2L3CorrectorChain * process.jetAwareCleaner +


### PR DESCRIPTION
While using MET and MT can be a bad idea in general, since it's correlated with the PF ID, it looks like it can be of use to when looking for the isolation and SIP efficiencies for soft muons that already pass the ID.

This PR is for 76X. I'd like to test this and #28 in 76X, then merge them and then forward-port the 76X to 80X (that will also carry over #26 which I already merged in 76X)

Giovanni
